### PR TITLE
Import fixes in `train.py` and `readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ If you're new to <strong>rejax</strong> and want to learn more about it,
 - Use `jax.vmap` and `jax.pmap` on the initial seed or hyperparameters to train a whole batch of agents in parallel! 
 
 ```python
-from rejax.algos import get_agent
+import jax
+from rejax import get_agent
 
 # Get train function and initialize config for training
 train_fn, config_cls = get_agent("sac")

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         "numpy",
         "brax",
         "evosax",
+        "mle_logging"
     ],
 )

--- a/train.py
+++ b/train.py
@@ -4,11 +4,11 @@ import jax
 import jax.numpy as jnp
 from matplotlib import pyplot as plt
 
-from rejax import get_algo
+from rejax import get_agent
 
 
 def main(algo_str, config, seed_id, num_seeds, time_fit):
-    train_fn, config_cls = get_algo(algo_str)
+    train_fn, config_cls = get_agent(algo_str)
     old_train_config = config_cls.from_dict(config)
 
     def eval_callback(config, ts, rng):
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         help="Number of seeds to roll out.",
     )
 
-    args, _ = parser.parse_known_args()
+    args = parser.parse_args()
     config = load_config(args.config, True)
     main(
         args.algorithm,


### PR DESCRIPTION
Hi @keraJLi,

Thank you very much for sharing this library! It's a very cool project and I'm sure it'll be useful for many people and also in my work!

I was just working on modifying rejax for my own purposes and came across three tiny bugs, so I thought I'd open a PR to contribute the fixes.

The issues are 
### 1) The import in the readme.md is wrong
```
>>> from rejax.algos import get_agent
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'get_agent' from 'rejax.algos' (/workspaces/rejax/rejax/algos/__init__.py)
```
It should be  `from rejax import get_agent`

### 2) In `train.py`  `get_algo` is used instead of `get_agent`, leading to this error

```
root@5f3d36c609d7:/workspaces/rejax# python train.py --config configs/acrobot.yaml --algorithm ppo
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspaces/rejax/train.py", line 90, in <module>
    main(
  File "/workspaces/rejax/train.py", line 31, in main
    _, (_, returns) = vmap_train(train_config, keys)
TypeError: PPO() takes no arguments
```

### 3) `setup.py` is missing the `mle_logging` dependency, so I added it.

Finally, I also changed the argument parsing to use `parse_args` instead of `parse_known_args`, such that it raises an error when unknown arguments are parsed. This is not really necessary, but a nice quality of life improvement in my opinion.

Anyway feel free to change it around and again, thank you so much for sharing this project!