### PR TITLE
Deprecate `from_dict` and `get_agent` and adress import issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ If you're new to <strong>rejax</strong> and want to learn more about it,
 - Use `jax.vmap` and `jax.pmap` on the initial seed or hyperparameters to train a whole batch of agents in parallel! 
 
 ```python
-from rejax.algos import get_agent
+from rejax import get_algo
 
 # Get train function and initialize config for training
-train_fn, config_cls = get_agent("sac")
+algo, config_cls = get_algo("sac")
 train_config = config_cls.create(env="CartPole-v1", learning_rate=0.001)
 
 # Jit the training function
-jitted_train_fn = jax.jit(train_fn)
+jitted_train_fn = jax.jit(algo.train)
 
 # Vmap training function over 300 initial seeds
 vmapped_train_fn = jax.vmap(jitted_train_fn, in_axes=(None, 0))

--- a/benchmark/train.py
+++ b/benchmark/train.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from flax import serialization
 
-from rejax.algos import get_agent
+from rejax.algos import get_algo
 from rejax.evaluate import make_evaluate as make_evaluate_vanilla
 
 
@@ -150,14 +150,14 @@ def main(args, config):
         )
 
     # Prepare train function and config
-    train_fn, config_cls = get_agent(args.algorithm)
-    train_config = config_cls.from_dict(config)
+    algo, config_cls = get_algo(args.algorithm)
+    train_config = config_cls.create(**config)
     evaluate = make_evaluate(logger, train_config.env, train_config.env_params)
     train_config = train_config.replace(eval_callback=evaluate)
 
     key = jax.random.PRNGKey(args.global_seed)
     keys = jax.random.split(key, args.num_seeds)
-    vmap_train = jax.jit(jax.vmap(train_fn, in_axes=(None, 0)))
+    vmap_train = jax.jit(jax.vmap(algo.train, in_axes=(None, 0)))
 
     # Time compilation
     start = time.process_time()

--- a/examples/evo_hyperopt.py
+++ b/examples/evo_hyperopt.py
@@ -23,7 +23,7 @@ POPULATION_SIZE = 10
 EVAL_SEEDS = 10
 
 # Load SAC agent's train function and config
-train_fn, config_cls = get_algo("sac")
+algo, config_cls = get_algo("sac")
 
 # Static parameters, cannot be vmapped (except target_entropy_ratio, which is unused)
 static_params = {
@@ -51,8 +51,8 @@ optim_params = {
 @partial(jax.vmap, in_axes=(0, None))
 @partial(jax.vmap, in_axes=(None, 0))
 def evaluate_fitness(meta_params, rng):
-    config = config_cls.from_dict({**static_params, **meta_params})
-    train_state, (lenghts, returns) = train_fn(config, rng)
+    config = config_cls.create(**static_params, **meta_params)
+    train_state, (lenghts, returns) = algo.train(config, rng)
 
     # Take mean over evaluation seeds and calculate fitness as final return
     fitness = returns.mean(axis=1)[-1]

--- a/examples/wandb_integration.py
+++ b/examples/wandb_integration.py
@@ -28,8 +28,8 @@ CONFIG = {
 
 wandb.init(project="my-awesome-project", config=CONFIG)
 
-train_fn, config_cls = get_algo("ppo")
-config = config_cls.from_dict(CONFIG)
+algo, config_cls = get_algo("ppo")
+config = config_cls.create(**CONFIG)
 eval_callback = config.eval_callback
 
 
@@ -58,6 +58,6 @@ config = config.replace(eval_callback=wandb_callback)
 
 rng = jax.random.PRNGKey(0)
 print("Compiling...")
-compiled_train = jax.jit(train_fn).lower(config, rng).compile()
+compiled_train = jax.jit(algo.train).lower(config, rng).compile()
 print("Training...")
 compiled_train(config, rng)

--- a/rejax/__init__.py
+++ b/rejax/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from rejax.algos.ddpg import DDPG, DDPGConfig
 from rejax.algos.dqn import DQN, DQNConfig
 from rejax.algos.ppo import PPO, PPOConfig
@@ -16,6 +18,12 @@ _algos = {
 def get_agent(agent_str):
     """Gets a pair of `(train_fn, config_cls)`. Will be deprecated in the future, exists
     mainly for backwards compatibility."""
+
+    warnings.warn(
+        "get_agent is deprecated and will be removed in the future. "
+        "Use get_algo instead.",
+        DeprecationWarning,
+    )
     algo_cls, config_cls = _algos[agent_str]
     return algo_cls.train, config_cls
 

--- a/rejax/algos/ddpg/core.py
+++ b/rejax/algos/ddpg/core.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, Tuple
 
 import chex
@@ -5,8 +6,6 @@ from flax import linen as nn
 from flax import struct
 from gymnax.environments.environment import Environment
 from jax import numpy as jnp
-
-from rejax.algos.ddpg.ddpg import DDPG
 
 
 class DDPGConfig(struct.PyTreeNode):
@@ -46,12 +45,17 @@ class DDPGConfig(struct.PyTreeNode):
     @classmethod
     def create(cls, **kwargs):
         """Create a config object from keyword arguments."""
-        return cls.from_dict(kwargs)
+        return cls._from_dict(kwargs)
 
     @classmethod
     def from_dict(cls, config):
         """Create a config object from a dictionary. Exists mainly for backwards
         compatibility and will be deprecated in the future."""
+        warnings.warn("from_dict is deprecated, use create instead.")
+        return cls._from_dict(config)
+
+    @classmethod
+    def _from_dict(cls, config):
         from copy import deepcopy
 
         import gymnax

--- a/rejax/algos/dqn/core.py
+++ b/rejax/algos/dqn/core.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Callable
 
@@ -55,12 +56,17 @@ class DQNConfig(struct.PyTreeNode):
     @classmethod
     def create(cls, **kwargs):
         """Create a config object from keyword arguments."""
-        return cls.from_dict(kwargs)
+        return cls._from_dict(kwargs)
 
     @classmethod
     def from_dict(cls, config):
         """Create a config object from a dictionary. Exists mainly for backwards
         compatibility and will be deprecated in the future."""
+        warnings.warn("from_dict is deprecated, use create instead.")
+        return cls._from_dict(config)
+
+    @classmethod
+    def _from_dict(cls, config):
         config = deepcopy(config)  # Because we're popping from it
 
         if isinstance(config["env"], str):

--- a/rejax/algos/ppo/core.py
+++ b/rejax/algos/ppo/core.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Callable
 
@@ -56,12 +57,17 @@ class PPOConfig(struct.PyTreeNode):
     @classmethod
     def create(cls, **kwargs):
         """Create a config object from keyword arguments."""
-        return cls.from_dict(kwargs)
+        return cls._from_dict(kwargs)
 
     @classmethod
     def from_dict(cls, config):
         """Create a config object from a dictionary. Exists mainly for backwards
         compatibility and will be deprecated in the future."""
+        warnings.warn("from_dict is deprecated, use create instead.")
+        return cls._from_dict(config)
+
+    @classmethod
+    def _from_dict(cls, config):
         config = deepcopy(config)  # Because we're popping from it
 
         if isinstance(config["env"], str):

--- a/rejax/algos/sac/core.py
+++ b/rejax/algos/sac/core.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Callable
 
@@ -72,12 +73,17 @@ class SACConfig(struct.PyTreeNode):
     @classmethod
     def create(cls, **kwargs):
         """Create a config object from keyword arguments."""
-        return cls.from_dict(kwargs)
+        return cls._from_dict(kwargs)
 
     @classmethod
-    def from_dict(cls, config: dict):
+    def from_dict(cls, config):
         """Create a config object from a dictionary. Exists mainly for backwards
         compatibility and will be deprecated in the future."""
+        warnings.warn("from_dict is deprecated, use create instead.")
+        return cls._from_dict(config)
+
+    @classmethod
+    def _from_dict(cls, config):
         config = deepcopy(config)  # Because we're popping from it
 
         if isinstance(config["env"], str):

--- a/rejax/algos/td3/core.py
+++ b/rejax/algos/td3/core.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, Callable
 
@@ -61,13 +62,17 @@ class TD3Config(struct.PyTreeNode):
     @classmethod
     def create(cls, **kwargs):
         """Create a config object from keyword arguments."""
-        return cls.from_dict(kwargs)
+        return cls._from_dict(kwargs)
 
     @classmethod
     def from_dict(cls, config):
         """Create a config object from a dictionary. Exists mainly for backwards
         compatibility and will be deprecated in the future."""
+        warnings.warn("from_dict is deprecated, use create instead.")
+        return cls._from_dict(config)
 
+    @classmethod
+    def _from_dict(cls, config):
         config = deepcopy(config)  # Because we're popping from it
 
         if isinstance(config["env"], str):

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         "numpy",
         "brax",
         "evosax",
+        "pyyaml",
     ],
 )


### PR DESCRIPTION
Deprecated `Config.from_dict` and `rejax.get_agent`. Updated examples accordingly.
Additionally adresses everything in #7.