### PR TITLE
Make deepcopy of config before modifying

### DIFF
--- a/src/rejax/algos/algorithm.py
+++ b/src/rejax/algos/algorithm.py
@@ -35,6 +35,7 @@ class Algorithm(struct.PyTreeNode):
 
     @classmethod
     def create(cls, **config):
+        config = deepcopy(config)
         env, env_params = cls.create_env(config)
         agent = cls.create_agent(config, env, env_params)
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -47,3 +47,4 @@ class TestConfigs(unittest.TestCase):
                             f"Failed to create {algo} with config '{config_path}': "
                             f"{type(e).__name__}: {str(e)}"
                         )
+                        

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-
+from copy import deepcopy
 from yaml import safe_load
 
 from rejax import get_algo
@@ -39,9 +39,10 @@ class TestConfigs(unittest.TestCase):
                     continue
                 with self.subTest(config_opath=config_path, algo=algo):
                     try:
+                        original_config = deepcopy(config)
                         algo_cls = get_algo(algo)
                         algo_cls.create(**config)
-                        algo_cls.create(**config)
+                        self.assertEqual(config, original_config)
                     except Exception as e:
                         self.fail(
                             f"Failed to create {algo} with config '{config_path}': "

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -32,7 +32,7 @@ class TestConfigs(unittest.TestCase):
                             f"{type(e).__name__}: {str(e)}"
                         )
 
-    def test_create_algo_with_same_config(self) -> None:
+    def test_create_does_not_modify_config(self) -> None:
         for config_path, configs_env in self.configs.items():
             for algo, config in configs_env.items():
                 if config.get("env", "").startswith("navix"):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -45,7 +45,6 @@ class TestConfigs(unittest.TestCase):
                         self.assertEqual(config, original_config)
                     except Exception as e:
                         self.fail(
-                            f"Failed to create {algo} with config '{config_path}': "
+                            f"Config '{config_path}' for {algo} has been modified: "
                             f"{type(e).__name__}: {str(e)}"
                         )
-                        

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -31,3 +31,19 @@ class TestConfigs(unittest.TestCase):
                             f"Failed to create {algo} with config '{config_path}': "
                             f"{type(e).__name__}: {str(e)}"
                         )
+
+    def test_create_algo_with_same_config(self) -> None:
+        for config_path, configs_env in self.configs.items():
+            for algo, config in configs_env.items():
+                if config.get("env", "").startswith("navix"):
+                    continue
+                with self.subTest(config_opath=config_path, algo=algo):
+                    try:
+                        algo_cls = get_algo(algo)
+                        algo_cls.create(**config)
+                        algo_cls.create(**config)
+                    except Exception as e:
+                        self.fail(
+                            f"Failed to create {algo} with config '{config_path}': "
+                            f"{type(e).__name__}: {str(e)}"
+                        )


### PR DESCRIPTION
### Problem 
When initialising a new algo class for a second time, we can get an error due to `agent_kwargs` being modified in place. 

### Proposed solution
Add a deepcopy of the config before it is modified by the various algo classes. Also added a basic test case for this.